### PR TITLE
adds /fossa-invite accepted command to ob workflow

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -56,3 +56,43 @@ We deploy using plain manifests (no Helm). Key targets:
 - Verify:
   - `kubectl -n maintainerd get pvc,deploy,svc,ing`
   - The Deployment runs an initContainer that bootstraps the DB before the server starts.
+
+## Manual Testing (alternate org/repo)
+
+Use environment variables `ORG` and `REPO` to point the server at a different GitHub org/repo for testing (e.g., your fork). The Deployment passes `-org=$ORG` and `-repo=$REPO` to the server, which resolves those from the environment injected via the bootstrap Secret.
+
+- Set env in `.envrc` (example):
+
+  - `export ORG=robertkielty`
+  - `export REPO=maintainerd`
+
+- Regenerate and apply the bootstrap Secret (injects env into the Pod):
+
+  - `make env`
+  - `make apply-env`
+
+- Apply/roll the Deployment to pick up changes (if already applied, a rollout is enough):
+
+  - `make manifests-apply`  (or)
+  - `kubectl -n maintainerd rollout restart deploy/maintainerd && \\
+     kubectl -n maintainerd rollout status deploy/maintainerd --timeout=180s`
+
+- Configure the GitHub webhook on the alternate repo:
+
+  - Payload URL: `http://maintainerd.localtest.me/webhook`
+  - Content type: `application/json`
+  - Secret: must match `GITHUB_WEBHOOK_SECRET` in `maintainerd-bootstrap-env`
+  - Events: at least “Issues” and “Issue comments”
+
+- Exercise the flow on the test repo:
+
+  - Create or use an onboarding issue titled `"[PROJECT ONBOARDING] <project>"`
+  - Add label `fossa` (creates the FOSSA team via the label flow)
+  - Assign yourself to the issue (assignees can trigger commands)
+  - Comment exactly: `/fossa-invite accepted`
+  - Watch logs: `kubectl -n maintainerd logs deploy/maintainerd -f`
+
+- Notes:
+
+  - Public comments never include email addresses; only GitHub handles are shown.
+  - If the team does not exist, the server comments instructions to add the `fossa` label first and retry.

--- a/features/fossa/add-user-to-team.feature
+++ b/features/fossa/add-user-to-team.feature
@@ -1,0 +1,98 @@
+@fossa @issue-comment
+Feature: Add accepted FOSSA invitee to the project team
+  When a maintainer (or a user assigned to the onboarding issue) confirms
+  acceptance of an invitation to join the CNCF FOSSA organization
+  via an onboarding issue comment, the server adds the maintainers
+  (all registered for the project) to the project's FOSSA team and records the action.
+
+  Background:
+    Given a CNCF project "<project>" exists in maintainerd
+    And an onboarding issue exists titled "[PROJECT ONBOARDING] <project>"
+    And the project has a FOSSA team named "<project>"
+    And maintainerd contains maintainer "<gh_user>" with email "<email>" for "<project>"
+    # Authorization via assignees; no separate staff registry is required here
+
+  Rule: Authorization
+    - Maintainers of the project may trigger processing for their project.
+    - Any GitHub user assigned to the onboarding issue may trigger processing for that project.
+
+  Rule: Acceptance verification
+    - The server verifies there is no active/pending invitation for the email before adding to the team.
+
+  Rule: Command matching
+    - The trigger must be exactly "/fossa-invite accepted" (case-sensitive, no extra whitespace).
+
+  Rule: Privacy in public comments
+    - Public comments must never include email addresses; reference maintainers by GitHub handle only.
+
+  Rule: Scope of action
+    - The command processes all registered maintainers for the project, not only the comment author.
+
+  Rule: Unauthorized attempts
+    - If the comment author is neither a registered maintainer of the project nor assigned to the onboarding issue,
+      the server posts a denial comment, makes no FOSSA changes, and records an audit entry "FOSSA_ADD_MEMBER_DENIED".
+
+  Scenario: Maintainer confirms acceptance via issue comment (all maintainers processed)
+    Given a valid GitHub webhook signature
+    And an issue comment with body "/fossa-invite accepted" authored by "<gh_user>" on the onboarding issue
+    When the onboarding server processes the comment
+    Then the server verifies acceptance status for each registered maintainer of "<project>"
+    And for each maintainer without a pending invitation who is not yet a member, the server adds them as "Team Admin"
+    And for maintainers already in the team, the server takes no action
+    And the server posts a summary comment listing outcomes per maintainer by GitHub handle only
+    And audit log entries record action "FOSSA_ADD_MEMBER" for maintainers newly added
+
+  Scenario: Some maintainers are already members
+    Given at least one registered maintainer is already a member of the FOSSA team
+    When a maintainer comments "/fossa-invite accepted" on the onboarding issue
+    Then the server performs membership checks for all registered maintainers
+    And the server posts a comment listing GitHub handles already in the team
+    
+
+  Scenario: Some maintainers still have pending invitations
+    Given one or more registered maintainers have a pending FOSSA invitation
+    When a maintainer comments "/fossa-invite accepted" on the onboarding issue
+    Then the server skips adding those maintainers with pending invitations
+    And the server posts a comment indicating which GitHub handles still have pending invitations
+    
+
+  Scenario: Issue assignee triggers addition for all project maintainers
+    Given the issue comment author is assigned to the onboarding issue
+    And the maintainer "<gh_user>" exists in maintainerd for the project with email "<email>"
+    When the staff member comments "/fossa-invite accepted" on the onboarding issue
+    Then the server processes all registered maintainers as per the main scenario
+    And the server posts a summary comment listing actions per maintainer by handle
+    And audit log entries record action "FOSSA_ADD_MEMBER" for added maintainers
+
+  Scenario: Unauthorized actor is rejected
+    Given the issue comment author is neither a maintainer of the project nor assigned to the onboarding issue
+    When they comment "/fossa-invite accepted" on the onboarding issue
+    Then the server posts a comment including "You are not authorized to perform this action"
+    And no FOSSA changes are made
+    And an audit log entry records action "FOSSA_ADD_MEMBER_DENIED"
+
+  Scenario: Team missing is created and members added
+    Given no FOSSA team exists for the project
+    And the maintainer comments "/fossa-invite accepted" on the onboarding issue
+    When the onboarding server processes the comment
+    Then the server creates a FOSSA team named "<project>"
+    And the server processes all registered maintainers:
+      - add any not-yet-members as "Team Admin"
+      - leave existing members unchanged
+    And the server posts a comment including "Created FOSSA team <project>" and lists handle outcomes
+    And audit log entries record "FOSSA_TEAM_CREATED" and "FOSSA_ADD_MEMBER" for added maintainers
+
+  Scenario: Non-matching comment is ignored
+    Given a comment body that does not exactly match "/fossa-invite accepted"
+    When the onboarding server processes the comment
+    Then the server takes no action on FOSSA membership
+    And no audit log entry is created
+
+  Scenario: Comment author is not a registered maintainer
+    Given the issue comment author is not a registered maintainer for the project
+    When the author comments "/fossa-invite accepted" on the onboarding issue
+    Then the server posts a comment refusing the action due to missing registration
+    And no FOSSA changes are made
+    And an audit log entry records action "FOSSA_ADD_MEMBER_DENIED"
+
+  

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module maintainerd
 go 1.24
 
 require (
-	github.com/erhanakp/sugaredgorm v0.0.1
+	github.com/google/go-github/v55 v55.0.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/oauth2 v0.30.0
 	google.golang.org/api v0.238.0
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.30.0
@@ -25,7 +26,6 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
-	github.com/google/go-github/v55 v55.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -51,7 +51,6 @@ require (
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
-	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUK
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/erhanakp/sugaredgorm v0.0.1 h1:V99ETAieC0cmdKb6OkjagdpXWrjNmt52tRKpvI0kwMg=
-github.com/erhanakp/sugaredgorm v0.0.1/go.mod h1:ZXo36ga1RVuB3WebeM33Q9DFMv5uGZmp+srO55jM6vU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -138,6 +136,8 @@ google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
+gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=

--- a/main.go
+++ b/main.go
@@ -2,9 +2,10 @@
 package main
 
 import (
-	"flag"
-	"log"
-	"os"
+    "flag"
+    "log"
+    "os"
+    "strings"
 
 	"maintainerd/onboarding"
 )
@@ -20,17 +21,40 @@ func main() {
 		ghOrg         = flag.String("org", "cncf", "Name of the GitHub org (e.g. cncf)")
 		ghToken       = flag.String("gh-api", "", "GitHub API token (raw string)")
 	)
-	flag.Parse()
+    flag.Parse()
 
-	if *webhookSecret == "" {
-		*webhookSecret = os.Getenv("GITHUB_WEBHOOK_SECRET")
-	}
+    if *webhookSecret == "" {
+        *webhookSecret = os.Getenv("GITHUB_WEBHOOK_SECRET")
+    }
 	if *webhookSecret == "" {
 		log.Fatal("must provide --webhook-secret or set GITHUB_WEBHOOK_SECRET")
 	}
-	if *ghToken == "" {
-		*ghToken = os.Getenv("GITHUB_API_TOKEN")
-	}
+    if *ghToken == "" {
+        *ghToken = os.Getenv("GITHUB_API_TOKEN")
+    }
+
+    // Allow environment overrides for org/repo.
+    // Two modes supported:
+    // 1) If flags are left at their defaults (cncf/sandbox), use ORG/REPO env if set.
+    // 2) If flags are provided as "$ENVNAME", resolve from that env variable.
+    if *ghOrg == "cncf" {
+        if v := os.Getenv("ORG"); v != "" {
+            *ghOrg = v
+        }
+    } else if strings.HasPrefix(*ghOrg, "$") {
+        if v := os.Getenv(strings.TrimPrefix(*ghOrg, "$")); v != "" {
+            *ghOrg = v
+        }
+    }
+    if *ghRep == "sandbox" {
+        if v := os.Getenv("REPO"); v != "" {
+            *ghRep = v
+        }
+    } else if strings.HasPrefix(*ghRep, "$") {
+        if v := os.Getenv(strings.TrimPrefix(*ghRep, "$")); v != "" {
+            *ghRep = v
+        }
+    }
 
 	// instantiate and initialize listener
 	listener := &onboarding.EventListener{


### PR DESCRIPTION
  - /fossa-invite accepted comments now triggers adding a maintainer to their project team on the foundation;s FOSSA along with a Markdown summary reply comment on the ob issue (onboarding/server.go:89, helpers at onboarding/server.go:355).
  - FOSSA client adds pagination, pending-invite detection, team membership writes, and broader provider metadata to support the new flow (plugins/fossa/ client.go:66, plugins/fossa/client.go:279).
  - CLI defaults can be overridden via ORG/REPO env vars for alternate testing scenarios (main.go:36).
  - Acceptance criteria for adding invitees to teams is captured in a new Gherkin spec (features/fossa/add-user-to-team.feature:1).
  - Tooling and ops updates include context-aware Make targets plus new maintainerd-drain/kind-load-image, along with checked-in manifests and helper scripts for local clusters (Makefile:7, deploy/manifests/deployment.yaml:1, hack/export-db.sh:1, hack/send-webhook.py:1).
  - README now documents manual test steps for running against forked orgs/repos (README.MD:56).